### PR TITLE
Fix errors

### DIFF
--- a/torch_exp/pipeline_torch.py
+++ b/torch_exp/pipeline_torch.py
@@ -106,7 +106,7 @@ def train_efficient_gradient_clipping(
 
             curr_time = starter.elapsed_time(ender) / 1000
             # total_time_epoch += curr_time
-            total_time_epoch = total_time_prf
+            total_time_epoch += total_time_prf
             if lib == "private_vision":
                 train_loss += loss.mean().item()
             else:

--- a/torch_exp/pipeline_torch.py
+++ b/torch_exp/pipeline_torch.py
@@ -98,12 +98,12 @@ def train_efficient_gradient_clipping(
                     optimizer.step()
                     optimizer.zero_grad()
 
+            ender.record()  # type: ignore
             torch.cuda.synchronize()
             end_time = time.perf_counter()
 
             total_time_prf = end_time - start_time
-            ender.record()  # type: ignore
-
+            
             curr_time = starter.elapsed_time(ender) / 1000
             # total_time_epoch += curr_time
             total_time_epoch += total_time_prf
@@ -131,8 +131,9 @@ def train_efficient_gradient_clipping(
                 correct += correct_batch
                 total_batch = 0
                 correct_batch = 0
-        torch.cuda.synchronize()
+        
         ender_t.record()  # type: ignore
+        torch.cuda.synchronize()
 
         curr_t = starter_t.elapsed_time(ender_t) / 1000
         total_time += curr_t


### PR DESCRIPTION
Fix the time recording for the train efficient gradient clipping and also fix the bug about CUDA error: device not ready. It was failing because I was calling synchronize before ending the time record. First we need to call the record, and then the torch.cuda.synchronize will wait till everything is ready.