### PR TITLE
refactor: move sampling functions to package, rename functions and add typing and docstrings.

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -2,6 +2,11 @@ import numpy as np
 import jax
 
 
+def normalize_and_reshape(imgs):
+    normalized = ((imgs / 255.0) - 0.5) / 0.5
+    return jax.image.resize(normalized, shape=(len(normalized), 3, 224, 224), method="bilinear")
+
+
 def import_data_efficient_mask():
     train_images = np.load("numpy_cifar100/train_images.npy")
     train_labels = np.load("numpy_cifar100/train_labels.npy")

--- a/src/example.py
+++ b/src/example.py
@@ -191,7 +191,7 @@ def main(args):
 
         print(logical_batch_size / duration, flush=True)
 
-        acc_iter = model_evaluation(state, splits_test, splits_labels)
+        acc_iter = model_evaluation(state, splits_test, splits_labels, num_classes=num_classes)
         print("iteration", t, "acc", acc_iter, flush=True)
 
         # Compute privacy guarantees
@@ -205,7 +205,7 @@ def main(args):
         privacy_results = {"eps_rdp": epsilon, "delta_rdp": delta}
         print(privacy_results, flush=True)
 
-    acc_last = model_evaluation(state, splits_test, splits_labels)
+    acc_last = model_evaluation(state, splits_test, splits_labels, num_classes=num_classes)
 
     print("times \n", times, flush=True)
 

--- a/src/example.py
+++ b/src/example.py
@@ -19,7 +19,7 @@ from jax_mask_efficient import (
     add_trees,
     clip_and_accumulate_physical_batch,
     model_evaluation,
-    noise_addition,
+    add_Gaussian_noise,
     update_model,
 )
 
@@ -178,7 +178,7 @@ def main(args):
                 masks,
             ),
         )
-        noisy_grad = noise_addition(noise_rng, accumulated_clipped_grads, noise_std, C)
+        noisy_grad = add_Gaussian_noise(noise_rng, accumulated_clipped_grads, noise_std, C)
 
         # update
         state = jax.block_until_ready(update_model(state, noisy_grad))

--- a/src/example.py
+++ b/src/example.py
@@ -11,10 +11,11 @@ import math
 import time
 
 from data import import_data_efficient_mask
+from models import create_train_state
+
 from dp_accounting_utils import compute_epsilon, calculate_noise
 
 from jax_mask_efficient import (
-    create_train_state,
     compute_physical_batch_per_example_gradients,
     add_trees,
     clip_and_accumulate_physical_batch,

--- a/src/example.py
+++ b/src/example.py
@@ -192,7 +192,7 @@ def main(args):
 
         print(logical_batch_size / duration, flush=True)
 
-        acc_iter = model_evaluation(state, splits_test, splits_labels, num_classes=num_classes)
+        acc_iter = model_evaluation(state, splits_test, splits_labels)
         print("iteration", t, "acc", acc_iter, flush=True)
 
         # Compute privacy guarantees
@@ -206,7 +206,7 @@ def main(args):
         privacy_results = {"eps_rdp": epsilon, "delta_rdp": delta}
         print(privacy_results, flush=True)
 
-    acc_last = model_evaluation(state, splits_test, splits_labels, num_classes=num_classes)
+    acc_last = model_evaluation(state, splits_test, splits_labels)
 
     print("times \n", times, flush=True)
 

--- a/src/example.py
+++ b/src/example.py
@@ -21,6 +21,7 @@ from jax_mask_efficient import (
     clip_and_accumulate_physical_batch,
     model_evaluation,
     add_Gaussian_noise,
+    poisson_sample_logical_batch_size,
     update_model,
 )
 
@@ -133,10 +134,7 @@ def main(args):
 
         #######
         # poisson subsample
-        actual_batch_size = jax.device_put(
-            jax.random.bernoulli(binomial_rng, shape=(dataset_size,), p=q).sum(),
-            jax.devices("cpu")[0],
-        )
+        actual_batch_size = poisson_sample_logical_batch_size(binomial_rng=binomial_rng, dataset_size=dataset_size, q=q)
         n_physical_batches = actual_batch_size // physical_bs + 1
         logical_batch_size = n_physical_batches * physical_bs
         n_masked_elements = logical_batch_size - actual_batch_size

--- a/src/example.py
+++ b/src/example.py
@@ -15,7 +15,7 @@ from dp_accounting_utils import compute_epsilon, calculate_noise
 
 from jax_mask_efficient import (
     create_train_state,
-    compute_per_example_gradients,
+    compute_physical_batch_per_example_gradients,
     add_trees,
     process_a_physical_batch,
     model_evaluation,
@@ -113,7 +113,7 @@ def main(args):
         mask = jax.lax.dynamic_slice(masks, (start_idx,), (physical_bs,))
 
         # compute grads and clip
-        per_example_gradients = compute_per_example_gradients(state, pb, yb)
+        per_example_gradients = compute_physical_batch_per_example_gradients(state, pb, yb)
         sum_of_clipped_grads_from_pb = process_a_physical_batch(per_example_gradients, mask, C)
         accumulated_clipped_grads = add_trees(accumulated_clipped_grads, sum_of_clipped_grads_from_pb)
 

--- a/src/example.py
+++ b/src/example.py
@@ -19,7 +19,7 @@ from jax_mask_efficient import (
     compute_physical_batch_per_example_gradients,
     add_trees,
     clip_and_accumulate_physical_batch,
-    get_technical_logical_batch,
+    get_padded_logical_batch,
     model_evaluation,
     add_Gaussian_noise,
     poisson_sample_logical_batch_size,
@@ -140,23 +140,23 @@ def main(args):
             binomial_rng=binomial_rng, dataset_size=dataset_size, q=q
         )
 
-        # determine tech_logical_bs so that there are full physical batches
+        # determine padded_logical_bs so that there are full physical batches
         # and create appropriate masks to mask out unnessary elements later
         masks, n_physical_batches = setup_physical_batches(
             actual_batch_size=actual_batch_size,
             physical_bs=physical_bs,
         )
 
-        # get random technical logical batches that are slighly larger actual batch size
-        tech_logical_batch_X, tech_logical_batch_y = get_technical_logical_batch(
-            batch_rng=batch_rng, tech_logical_batch_size=len(masks), train_X=train_images, train_y=train_labels
+        # get random padded logical batches that are slighly larger actual batch size
+        padded_logical_batch_X, padded_logical_batch_y = get_padded_logical_batch(
+            batch_rng=batch_rng, padded_logical_batch_size=len(masks), train_X=train_images, train_y=train_labels
         )
 
-        tech_logical_batch_X = tech_logical_batch_X.reshape(-1, 1, 3, orig_image_dimension, orig_image_dimension)
+        padded_logical_batch_X = padded_logical_batch_X.reshape(-1, 1, 3, orig_image_dimension, orig_image_dimension)
 
         # cast to GPU
-        tech_logical_batch_X = jax.device_put(tech_logical_batch_X, jax.devices("gpu")[0])
-        tech_logical_batch_y = jax.device_put(tech_logical_batch_y, jax.devices("gpu")[0])
+        padded_logical_batch_X = jax.device_put(padded_logical_batch_X, jax.devices("gpu")[0])
+        padded_logical_batch_y = jax.device_put(padded_logical_batch_y, jax.devices("gpu")[0])
         masks = jax.device_put(masks, jax.devices("gpu")[0])
 
         print("##### Starting gradient accumulation #####", flush=True)
@@ -175,8 +175,8 @@ def main(args):
             (
                 state,
                 accumulated_clipped_grads0,
-                tech_logical_batch_X,
-                tech_logical_batch_y,
+                padded_logical_batch_X,
+                padded_logical_batch_y,
                 masks,
             ),
         )

--- a/src/example.py
+++ b/src/example.py
@@ -127,6 +127,7 @@ def main(args):
         )
 
     for t in range(num_steps):
+        #TODO: Is this deprecated? See https://jax.readthedocs.io/en/latest/_autosummary/jax.random.PRNGKey.html.
         sampling_rng = jax.random.PRNGKey(t + 1)
         batch_rng, binomial_rng, noise_rng = jax.random.split(sampling_rng, 3)
 

--- a/src/example.py
+++ b/src/example.py
@@ -16,7 +16,7 @@ from models import create_train_state
 from dp_accounting_utils import compute_epsilon, calculate_noise
 
 from jax_mask_efficient import (
-    compute_physical_batch_per_example_gradients,
+    compute_per_example_gradients_physical_batch,
     add_trees,
     clip_and_accumulate_physical_batch,
     get_padded_logical_batch,
@@ -117,7 +117,7 @@ def main(args):
         mask = jax.lax.dynamic_slice(masks, (start_idx,), (physical_bs,))
 
         # compute grads and clip
-        per_example_gradients = compute_physical_batch_per_example_gradients(state, pb, yb)
+        per_example_gradients = compute_per_example_gradients_physical_batch(state, pb, yb)
         sum_of_clipped_grads_from_pb = clip_and_accumulate_physical_batch(per_example_gradients, mask, C)
         accumulated_clipped_grads = add_trees(accumulated_clipped_grads, sum_of_clipped_grads_from_pb)
 

--- a/src/example.py
+++ b/src/example.py
@@ -17,7 +17,7 @@ from jax_mask_efficient import (
     create_train_state,
     compute_physical_batch_per_example_gradients,
     add_trees,
-    process_a_physical_batch,
+    clip_and_accumulate_physical_batch,
     model_evaluation,
     noise_addition,
     update_model,
@@ -114,7 +114,7 @@ def main(args):
 
         # compute grads and clip
         per_example_gradients = compute_physical_batch_per_example_gradients(state, pb, yb)
-        sum_of_clipped_grads_from_pb = process_a_physical_batch(per_example_gradients, mask, C)
+        sum_of_clipped_grads_from_pb = clip_and_accumulate_physical_batch(per_example_gradients, mask, C)
         accumulated_clipped_grads = add_trees(accumulated_clipped_grads, sum_of_clipped_grads_from_pb)
 
         return (

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -54,7 +54,7 @@ def compute_physical_batch_per_example_gradients(
 
 
 @jax.jit
-def process_a_physical_batch(px_grads: jax.typing.ArrayLike, mask: jax.typing.ArrayLike, C: float):
+def clip_and_accumulate_physical_batch(px_grads: jax.typing.ArrayLike, mask: jax.typing.ArrayLike, C: float):
 
     def _clip_mask_and_sum(x: jax.typing.ArrayLike, mask: jax.typing.ArrayLike, clipping_multiplier: float):
 

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -112,7 +112,7 @@ def setup_physical_batches(
 
 
 @jax.jit
-def compute_physical_batch_per_example_gradients(
+def compute_per_example_gradients_physical_batch(
     state: train_state.TrainState, batch_X: jax.typing.ArrayLike, batch_y: jax.typing.ArrayLike, num_classes: int
 ):
     """Computes the per-example gradients for a physical batch.

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -38,7 +38,7 @@ def compute_physical_batch_per_example_gradients(
 
     Returns
     -------
-    px_grads : jax.typing.ArrayLike 
+    px_grads : jax.typing.ArrayLike
         The per-sample gradients of the physical batch.
     """
 
@@ -72,7 +72,7 @@ def clip_and_accumulate_physical_batch(px_grads: jax.typing.ArrayLike, mask: jax
         is only computed to keep the physical batch size fixed.
     C : float
         The clipping norm of DP-SGD.
-    
+
     Returns
     -------
     acc_px_grads: jax.typing.ArrayLike
@@ -98,7 +98,27 @@ def clip_and_accumulate_physical_batch(px_grads: jax.typing.ArrayLike, mask: jax
 
 
 @jax.jit
-def add_Gaussian_noise(rng_key: jax.Array, accumulated_clipped_grads: jax.typing.ArrayLike, noise_std: float, C: float):
+def add_Gaussian_noise(
+    rng_key: jax.Array, accumulated_clipped_grads: jax.typing.ArrayLike, noise_std: float, C: float
+):
+    """Add Gaussian noise to the clipped and accumulated per-example gradients of a logical batch.
+
+    Parameters
+    ----------
+    rng_key : jax.Array
+        The PRNG key array for generating the Gaussian noise.
+    accumulated_clipped_grads : jax.typing.ArrayLike
+        The clipped and accumulated per-example gradients of a logical batch.
+    noise_std : float
+        The standard deviation to be added as computed with a privacy accountant.
+    C : float
+        The clipping norm of DP-SGD.
+
+    Returns
+    -------
+    noisy_grad : jax.typing.ArrayLike
+        The noisy gradient of the logical batch.
+    """
     num_vars = len(jax.tree_util.tree_leaves(accumulated_clipped_grads))
     treedef = jax.tree_util.tree_structure(accumulated_clipped_grads)
     new_key, *all_keys = jax.random.split(rng_key, num=num_vars + 1)

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -55,6 +55,23 @@ def compute_physical_batch_per_example_gradients(
 
 @jax.jit
 def clip_and_accumulate_physical_batch(px_grads: jax.typing.ArrayLike, mask: jax.typing.ArrayLike, C: float):
+    """Clip and accumulate per-example gradients of a physical batch.
+
+    Parameters
+    ----------
+    px_grads : jax.typing.ArrayLike
+        The per-sample gradients of the physical batch.
+    mask : jax.typing.ArrayLike
+        A mask to filter out gradients that are discarded as a small number of per-examples gradients
+        is only computed to keep the physical batch size fixed.
+    C : float
+        The clipping norm of DP-SGD.
+    
+    Returns
+    -------
+    acc_px_grads: jax.typing.ArrayLike
+        The clipped and accumulated per-example gradients after discarding the additional per-example gradients.
+    """
 
     def _clip_mask_and_sum(x: jax.typing.ArrayLike, mask: jax.typing.ArrayLike, clipping_multiplier: float):
 

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -42,17 +42,17 @@ def poisson_sample_logical_batch_size(binomial_rng: jax.Array, dataset_size: int
     return logical_batch_size
 
 
-def get_technical_logical_batch(
-    batch_rng: jax.Array, tech_logical_batch_size: int, train_X: jax.typing.ArrayLike, train_y: jax.typing.ArrayLike
+def get_padded_logical_batch(
+    batch_rng: jax.Array, padded_logical_batch_size: int, train_X: jax.typing.ArrayLike, train_y: jax.typing.ArrayLike
 ):
-    """Samples random technical logical batch from the data that is slightly larger than the actual logical bs
+    """Samples random padded logical batch from the data that is slightly larger than the actual logical bs
         but can be divided into n physical batches.
 
     Parameters
     ----------
     batch_rng : jax.Array
         The PRNG key array for sampling the batch.
-    tech_logical_batch_size : int
+    padded_logical_batch_size : int
         The size of the sampled batch (so that it can be divided into n physical batches).
     train_X : jax.typing.ArrayLike
         The training features.
@@ -61,19 +61,19 @@ def get_technical_logical_batch(
 
     Returns
     -------
-    tech_logical_batch_X : jax.typing.ArrayLike
-        The technical training features.
-    tech_logical_batch_y : jax.typing.ArrayLike
-        The technical logical batch training labels.
+    padded_logical_batch_X : jax.typing.ArrayLike
+        The padded training features.
+    padded_logical_batch_y : jax.typing.ArrayLike
+        The padded logical batch training labels.
     """
 
     # take the logical batch
     dataset_size = len(train_y)
-    indices = jax.random.permutation(batch_rng, dataset_size)[:tech_logical_batch_size]
-    tech_logical_batch_X = train_X[indices]
-    tech_logical_batch_y = train_y[indices]
+    indices = jax.random.permutation(batch_rng, dataset_size)[:padded_logical_batch_size]
+    padded_logical_batch_X = train_X[indices]
+    padded_logical_batch_y = train_y[indices]
 
-    return tech_logical_batch_X, tech_logical_batch_y
+    return padded_logical_batch_X, padded_logical_batch_y
 
 
 def setup_physical_batches(
@@ -99,10 +99,10 @@ def setup_physical_batches(
     """
     # ensure full physical batches of size `physical_bs` each
     n_physical_batches = actual_logical_batch_size // physical_bs + 1
-    tech_logical_batch_size = n_physical_batches * physical_bs
+    padded_logical_batch_size = n_physical_batches * physical_bs
 
     # masks (throw away n_masked_elements later as they are only required for computing)
-    n_masked_elements = tech_logical_batch_size - actual_logical_batch_size
+    n_masked_elements = padded_logical_batch_size - actual_logical_batch_size
     masks = jax.device_put(
         jnp.concatenate([jnp.ones(actual_logical_batch_size), jnp.zeros(n_masked_elements)]),
         jax.devices("cpu")[0],

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -45,7 +45,6 @@ def compute_physical_batch_per_example_gradients(
 
     def loss_fn(params, X, y):
         resized_X = resizer(X)
-        print(resized_X.shape, flush=True)
         logits = state.apply_fn(resized_X, params=params)[0]
         one_hot = jax.nn.one_hot(y, num_classes=num_classes)
         loss = optax.softmax_cross_entropy(logits=logits, labels=one_hot).flatten()

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -27,13 +27,19 @@ def compute_physical_batch_per_example_gradients(
 ):
     """Computes the per-example gradients for a physical batch.
 
-    Args:
-        state (train_state.TrainState): The model train state.
-        batch_X (jax.typing.ArrayLike): The features of the physical batch.
-        batch_y (jax.typing.ArrayLike): The labels of the physical batch.
+    Parameters
+    ----------
+    state : train_state.TrainState
+        The model train state.
+    batch_X : jax.typing.ArrayLike
+        The features of the physical batch.
+    batch_y : jax.typing.ArrayLike
+        The labels of the physical batch.
 
-    Returns:
-        px_grads (jax.typing.ArrayLike): The per-sample gradients of the physical batch.
+    Returns
+    -------
+    px_grads : jax.typing.ArrayLike 
+        The per-sample gradients of the physical batch.
     """
 
     resizer = lambda x: normalize_and_reshape(x)

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -4,9 +4,6 @@ import numpy as np
 
 from flax.training import train_state
 
-from collections import namedtuple
-
-from models import load_model
 from data import normalize_and_reshape
 
 
@@ -131,19 +128,6 @@ def add_Gaussian_noise(
 
     updates = add_trees(accumulated_clipped_grads, noise)
     return updates
-
-
-### Parameters for training
-
-
-def create_train_state(model_name: str, num_classes: int, image_dimension: int, config: namedtuple):
-    """Creates initial `TrainState`."""
-    rng, model, params = load_model(jax.random.PRNGKey(0), model_name, image_dimension, num_classes)
-
-    # set the optimizer
-    tx = optax.adam(config.learning_rate)
-    return train_state.TrainState.create(apply_fn=jax.jit(model.__call__), params=params, tx=tx)
-
 
 @jax.jit
 def update_model(state: train_state.TrainState, grads):

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -147,7 +147,27 @@ def compute_gradients_non_dp(
     mask: jax.typing.ArrayLike,
     num_classes: int,
 ):
-    #     """Computes gradients, loss and accuracy for a single batch."""
+    """Computes the non-DP gradients for a physical batch.
+
+    Parameters
+    ----------
+    state : train_state.TrainState
+        The model train state.
+    batch_X : jax.typing.ArrayLike
+        The features of the physical batch.
+    batch_y : jax.typing.ArrayLike
+        The labels of the physical batch.
+    mask : jax.typing.ArrayLike
+        A mask to filter out gradients that are discarded as a small number of gradients
+        is only computed to keep the physical batch size fixed.
+    num_classes : int
+        The number of classes for one-hot encoding.
+
+    Returns
+    -------
+    acc_grads: jax.typing.ArrayLike
+        The accumulated per-example gradients after discarding the additional gradients (see mask).
+    """
 
     resizer = lambda x: normalize_and_reshape(x)
 

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -22,10 +22,19 @@ def add_trees(x, y):
 
 
 @jax.jit
-def compute_per_example_gradients(
+def compute_physical_batch_per_example_gradients(
     state: train_state.TrainState, batch_X: jax.typing.ArrayLike, batch_y: jax.typing.ArrayLike
 ):
-    """Computes gradients, loss and accuracy for a single batch."""
+    """Computes the per-example gradients for a physical batch.
+
+    Args:
+        state (train_state.TrainState): The model train state.
+        batch_X (jax.typing.ArrayLike): The features of the physical batch.
+        batch_y (jax.typing.ArrayLike): The labels of the physical batch.
+
+    Returns:
+        px_grads (jax.typing.ArrayLike): The per-sample gradients of the physical batch.
+    """
 
     resizer = lambda x: normalize_and_reshape(x)
 

--- a/src/jax_mask_efficient.py
+++ b/src/jax_mask_efficient.py
@@ -98,7 +98,7 @@ def clip_and_accumulate_physical_batch(px_grads: jax.typing.ArrayLike, mask: jax
 
 
 @jax.jit
-def noise_addition(rng_key: jax.Array, accumulated_clipped_grads: jax.typing.ArrayLike, noise_std: float, C: float):
+def add_Gaussian_noise(rng_key: jax.Array, accumulated_clipped_grads: jax.typing.ArrayLike, noise_std: float, C: float):
     num_vars = len(jax.tree_util.tree_leaves(accumulated_clipped_grads))
     treedef = jax.tree_util.tree_structure(accumulated_clipped_grads)
     new_key, *all_keys = jax.random.split(rng_key, num=num_vars + 1)

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,19 @@
 import jax
+import optax
 import flax.linen as nn
 from transformers import FlaxViTForImageClassification
+from collections import namedtuple
+from flax.training import train_state
+from models import load_model
+
+
+def create_train_state(model_name: str, num_classes: int, image_dimension: int, optimizer_config: namedtuple):
+    """Creates initial `TrainState`."""
+    rng, model, params = load_model(jax.random.PRNGKey(0), model_name, image_dimension, num_classes)
+
+    # set the optimizer
+    tx = optax.adam(optimizer_config.learning_rate)
+    return train_state.TrainState.create(apply_fn=jax.jit(model.__call__), params=params, tx=tx)
 
 
 def load_model(rng, model_name, dimension, num_classes):


### PR DESCRIPTION
- add typing for missing functions
- add docstrings for most functions
- rename functions (`compute_physical_batch_per_example_gradients`, `clip_and_accumulate_physical_batch` and `add_Gaussian_noise`)
-  move `create_initial_state` to models.py as it seems specific
- move sampling of logical bs to function and creation of logical batches out of example to separate functions
- add TODOs for PRNG and acc method as they might need attention
- make `num_classes` a parameter where needed (it seemed that this was hardcoded to 100 before)